### PR TITLE
fix: skip archived results schemas and handle missing entity links in generate-files

### DIFF
--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -97,20 +97,24 @@ def generate_all_results_schema_files(
                 col.type in BenchlingFieldType.get_entity_link_types()
                 and col.entity_link is not None
             ):
-                if not col.is_multi:
-                    relationship_strings.append(
-                        f"""{TAB}{col_name}_entity = single_relationship("{entity_schemas_wh_name_to_classname[col.entity_link]}", {col_name})"""
-                    )
-                    import_strings.append(
-                        "from liminal.orm.relationship import single_relationship"
-                    )
-                else:
-                    relationship_strings.append(
-                        f"""{TAB}{col_name}_entities = multi_relationship("{entity_schemas_wh_name_to_classname[col.entity_link]}", {col_name})"""
-                    )
-                    import_strings.append(
-                        "from liminal.orm.relationship import multi_relationship"
-                    )
+                entity_classname = entity_schemas_wh_name_to_classname.get(
+                    col.entity_link
+                )
+                if entity_classname is not None:
+                    if not col.is_multi:
+                        relationship_strings.append(
+                            f"""{TAB}{col_name}_entity = single_relationship("{entity_classname}", {col_name})"""
+                        )
+                        import_strings.append(
+                            "from liminal.orm.relationship import single_relationship"
+                        )
+                    else:
+                        relationship_strings.append(
+                            f"""{TAB}{col_name}_entities = multi_relationship("{entity_classname}", {col_name})"""
+                        )
+                        import_strings.append(
+                            "from liminal.orm.relationship import multi_relationship"
+                        )
         for col_name, col in field_properties_dict.items():
             if not col.required and col.type:
                 init_strings.append(

--- a/liminal/results_schemas/utils.py
+++ b/liminal/results_schemas/utils.py
@@ -22,6 +22,8 @@ def get_converted_results_schemas(
     unit_id_to_name_map = get_unit_id_to_name_map(benchling_service)
     results_schemas_list = []
     for schema in results_schemas:
+        if schema.archiveRecord is not None:
+            continue
         schema_properties = ResultsSchemaProperties(
             name=schema.name,
             warehouse_name=schema.sqlIdentifier,


### PR DESCRIPTION
- Filter out archived results schemas (archiveRecord is not None) during file generation so only active schemas are written
- Gracefully handle missing entity links in results schema fields instead of raising a KeyError when the linked entity schema doesn't exist